### PR TITLE
Add compile-time exhaustiveness checking and guard combinators

### DIFF
--- a/.changeset/lucky-pandas-exhale.md
+++ b/.changeset/lucky-pandas-exhale.md
@@ -1,0 +1,48 @@
+---
+'@anilkumarthakur/match': minor
+---
+
+Add compile-time exhaustiveness checking and guard combinators.
+
+**`.exhaustive()`** — the checked counterpart to `get()`. It resolves the chain with no fallback, and
+only compiles once every member of the subject's union has an arm:
+
+```typescript
+type Status = 'active' | 'archived' | 'draft'
+
+match<Status, string>(status)
+  .on('active', () => 'Live')
+  .on('archived', () => 'Archived')
+  .exhaustive()
+//   ~~~~~~~~~~ Expected 1 arguments, but got 0.
+//              Parameter type: NonExhaustive<"draft">
+```
+
+The payoff is on the next change rather than today's: add a member to `Status` and every
+`.exhaustive()` chain over it fails the build until handled, where a `switch` default or an
+`.otherwise()` would silently take the fallback branch. `onAny()` participates too, covering every
+value it lists. It still throws `UnhandledMatchError` at runtime, since the guarantee is only as
+strong as the subject's declared type.
+
+Only literal arms count towards coverage — a predicate's outcome is not knowable statically, so a
+guard leaves the remainder untouched, and open-ended subjects like `string` are never exhaustible.
+Both are deliberate: the alternative is a guarantee the library cannot honour.
+
+**`not` / `allOf` / `anyOf`** — combinators that build one `Predicate<T>` from several, so a composed
+guard stays readable at the call site:
+
+```typescript
+match(user)
+  .on(allOf(isVerified, not(isSuspended)), () => 'ok')
+  .on(anyOf(isAdmin, isOwner), () => 'privileged')
+  .otherwise(() => 'blocked')
+```
+
+They short-circuit left to right like `&&`/`||`, and their empty cases follow
+`Array.prototype.every`/`some` (`allOf()` matches everything, `anyOf()` matches nothing) so a
+possibly-empty condition list can be spread into either.
+
+Also exports two new types, `Unmatched` and `NonExhaustive`, which drive the check.
+
+No breaking changes: `on()` and `onAny()` gained an inferred `const` type parameter for the pattern,
+but their existing call signatures, runtime behaviour and inference are unchanged.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -24,6 +24,9 @@ import {
 ### Functions
 
 - [`match(subject)`](/api/match) - Create a new match expression
+- [`not(predicate)`](#guard-combinators) - Negate a guard
+- [`allOf(...predicates)`](#guard-combinators) - Require every guard
+- [`anyOf(...predicates)`](#guard-combinators) - Require at least one guard
 
 ### Classes
 
@@ -36,21 +39,25 @@ import {
 - [`Predicate<T>`](/api/types#predicate-t) - Guard function type, `(value: T) => boolean`
 - [`Pattern<TSubject>`](/api/types#pattern-tsubject) - What `on()` accepts: a literal or a predicate
 - `MatchChain<TSubject, TResult>` - Interface describing the full chain surface
+- [`Unmatched<...>`](/api/types#unmatched-tsubject-tremaining-tpattern) - Cases left after one arm
+- [`NonExhaustive<T>`](/api/types#nonexhaustive-tremaining) - The argument `exhaustive()` demands
+  while cases are missing
 - `MatcherHandler<T>` - Deprecated alias for `Handler<T>`
 
 ## Quick Reference
 
-| Method                    | Purpose                             | Returns                      |
-| ------------------------- | ----------------------------------- | ---------------------------- |
-| `match(subject)`          | Create matcher                      | `Matcher<TSubject, TResult>` |
-| `.on(pattern, handler)`   | Add a literal or predicate case     | `this` (for chaining)        |
-| `.onAny(values, handler)` | Add multiple literal cases          | `this` (for chaining)        |
-| `.otherwise(handler)`     | Set default & resolve               | `TResult`                    |
-| `.default(handler)`       | PHP alias for `otherwise()`         | `TResult`                    |
-| `.get()`                  | Resolve without default (may throw) | `TResult`                    |
-| `.valueOf()`              | Deprecated alias for `get()`        | `TResult`                    |
-| `.run()`                  | Resolve to "did anything match?"    | `boolean`                    |
-| `.isMatched`              | Inspect match state (getter)        | `boolean`                    |
+| Method                    | Purpose                                | Returns                      |
+| ------------------------- | -------------------------------------- | ---------------------------- |
+| `match(subject)`          | Create matcher                         | `Matcher<TSubject, TResult>` |
+| `.on(pattern, handler)`   | Add a literal or predicate case        | `this` (for chaining)        |
+| `.onAny(values, handler)` | Add multiple literal cases             | `this` (for chaining)        |
+| `.otherwise(handler)`     | Set default & resolve                  | `TResult`                    |
+| `.default(handler)`       | PHP alias for `otherwise()`            | `TResult`                    |
+| `.get()`                  | Resolve without default (may throw)    | `TResult`                    |
+| `.exhaustive()`           | Resolve, requiring every case at build | `TResult`                    |
+| `.valueOf()`              | Deprecated alias for `get()`           | `TResult`                    |
+| `.run()`                  | Resolve to "did anything match?"       | `boolean`                    |
+| `.isMatched`              | Inspect match state (getter)           | `boolean`                    |
 
 ## Method Documentation
 
@@ -177,6 +184,63 @@ const result = match(value)
   .on('case', () => 'result')
   .get() // Must have matched!
 ```
+
+### `.exhaustive(): TResult`
+
+The checked counterpart to `get()`: resolves the chain, but only compiles once every member of the
+subject's union has an arm.
+
+**Returns:** The result from the matched handler
+
+**Throws:** `UnhandledMatchError` if no case matched at runtime
+
+**Example:**
+
+```typescript
+type Status = 'active' | 'archived' | 'draft'
+
+const label = (status: Status): string =>
+  match<Status, string>(status)
+    .on('active', () => 'Live')
+    .on('archived', () => 'Archived')
+    .on('draft', () => 'Draft')
+    .exhaustive() // ✅ nothing left over
+```
+
+Remove the `'draft'` arm and the call fails to compile with
+`Expected 1 arguments, but got 0` — the expected parameter is `NonExhaustive<"draft">`, naming the
+gap. Add a member to `Status` later and every `.exhaustive()` chain over it breaks until handled.
+
+Only literal arms count towards coverage: a predicate's outcome is not statically knowable, so a
+guard leaves the remainder intact. Open-ended subjects (`string`, `number`) are never exhaustible.
+See [Type Safety](/guide/type-safety) for the full rules.
+
+### Guard combinators
+
+`not`, `allOf` and `anyOf` build one `Predicate<T>` out of several, so a composed condition stays
+readable at the call site.
+
+```typescript
+import { allOf, anyOf, match, not } from '@anilkumarthakur/match'
+
+match(user)
+  .on(allOf(isVerified, not(isSuspended)), () => 'ok')
+  .on(anyOf(isAdmin, isOwner), () => 'privileged')
+  .otherwise(() => 'blocked')
+```
+
+| Helper                 | Matches when                   | With no arguments      |
+| ---------------------- | ------------------------------ | ---------------------- |
+| `not(p)`               | `p` does not match             | n/a                    |
+| `allOf(...predicates)` | every predicate matches        | matches **everything** |
+| `anyOf(...predicates)` | at least one predicate matches | matches **nothing**    |
+
+Evaluation short-circuits left to right, like `&&` and `||`. The empty cases follow
+`Array.prototype.every`/`some`, making it safe to spread a possibly-empty condition list.
+
+::: tip
+`anyOf` composes _conditions_; `.onAny()` compares the subject against a list of _values_.
+:::
 
 ### `.valueOf(): TResult`
 

--- a/docs/api/matcher.md
+++ b/docs/api/matcher.md
@@ -10,6 +10,7 @@ class Matcher<TSubject, TResult> implements MatchChain<TSubject, TResult> {
   otherwise(handler: () => TResult): TResult
   default(handler: () => TResult): TResult
   get(): TResult
+  exhaustive(): TResult
   /** @deprecated alias for get() */
   valueOf(): TResult
   run(): boolean
@@ -28,6 +29,11 @@ The `Matcher` class implements the match expression pattern with eager execution
 
 - `TSubject` - The type of values being matched
 - `TResult` - The return type of handler functions
+- `TPinned` - Internal, derived from `TResult`: whether the chain's result type was pinned by the
+  consumer or is being inferred from handlers
+- `TRemaining` - Internal, phantom: the subject values no arm has covered yet. Nothing at runtime
+  reads it; it exists so [`exhaustive()`](#exhaustive-tresult) can refuse to compile while cases are
+  outstanding.
 
 ## Constructor
 
@@ -195,6 +201,49 @@ try {
   }
 }
 ```
+
+### `exhaustive(): TResult`
+
+The checked counterpart to [`get()`](#get-tresult). Resolves the chain, but only compiles once every
+member of the subject's union has an arm.
+
+```typescript
+const result = matcher.exhaustive()
+```
+
+**Returns:** `TResult` - The result from the matched handler
+
+**Throws:** `UnhandledMatchError` if no case matched at runtime
+
+**Example:**
+
+```typescript
+import { match } from '@anilkumarthakur/match'
+
+type Status = 'active' | 'archived' | 'draft'
+
+const label = (status: Status): string =>
+  match<Status, string>(status)
+    .on('active', () => 'Live')
+    .on('archived', () => 'Archived')
+    .on('draft', () => 'Draft')
+    .exhaustive()
+```
+
+Drop an arm and the call stops compiling, naming the gap as
+`NonExhaustive<"draft">`. The real payoff arrives later: add a member to `Status` and every
+`.exhaustive()` chain over it fails the build until handled, where an `.otherwise()` would have
+quietly taken the fallback.
+
+::: warning Only literal arms count
+A predicate's outcome is not knowable statically, so a guard leaves the remainder untouched and
+`exhaustive()` stays unavailable. Use [`otherwise()`](#otherwise-handler-tresult) on guard-driven
+chains. Open-ended subjects (`string`, `number`) are likewise never exhaustible — narrow to a union
+first.
+:::
+
+It still throws at runtime: the guarantee is only as strong as the subject's declared type, and an
+unvalidated payload cast to `Status` can reach a chain the compiler believes is total.
 
 ### `valueOf(): TResult`
 

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -87,6 +87,57 @@ The check is wrapped in a tuple so it does not distribute over unions: for `stri
 the runtime decision depends on the value rather than the declared type, so both arms have to stay
 available. See [Function Subjects](/api/matcher#function-subjects).
 
+### `Unmatched<TSubject, TRemaining, TPattern>`
+
+The subject values still unaccounted for after one `.on(pattern)` arm. This is the machinery behind
+[`exhaustive()`](/api/#exhaustive-tresult).
+
+```typescript
+export type Unmatched<TSubject, TRemaining, TPattern> = [TSubject] extends [AnyFunction]
+  ? Exclude<TRemaining, TPattern>
+  : [TPattern] extends [AnyFunction]
+    ? TRemaining
+    : Exclude<TRemaining, TPattern>
+```
+
+Only a **literal** pattern proves anything about coverage: an arm matching `'a'` removes `'a'` from
+what remains. A predicate cannot be evaluated by the type system, so a predicate arm leaves the
+remainder untouched — which is why `.exhaustive()` never accepts a guard-driven chain. Reporting
+"still incomplete" there is the honest answer, not a limitation to work around.
+
+The function-subject case is tested first to mirror [`Pattern`](#pattern-tsubject): when the subject
+is itself a function the pattern is an identity comparison rather than a predicate, so it does
+narrow.
+
+```typescript
+type A = Unmatched<'a' | 'b', 'a' | 'b', 'a'> // 'b'
+type B = Unmatched<'a' | 'b', 'a' | 'b', Predicate<'a' | 'b'>> // 'a' | 'b'
+```
+
+**Note:** `Exclude` only removes members of a union, so a subject typed as the whole of `string`
+never narrows to `never` — correctly, since no finite set of arms covers every string.
+
+### `NonExhaustive<TRemaining>`
+
+The argument `.exhaustive()` demands while cases are still missing.
+
+```typescript
+export interface NonExhaustive<TRemaining> {
+  readonly missingCases: TRemaining
+  readonly nonExhaustive: never
+}
+```
+
+No value of this type can be produced — `nonExhaustive` is typed `never` — so the call cannot be
+satisfied. That is the entire point: the diagnostic is the feature, not the value. TypeScript reports
+the missing argument and names this type, whose `missingCases` parameter spells out on hover exactly
+which subject values are unhandled:
+
+```
+Argument of type 'string' is not assignable to parameter of
+type 'NonExhaustive<"archived" | "draft">'.
+```
+
 ### `MatcherHandler<T>`
 
 Deprecated alias for `Handler<T>`.
@@ -110,6 +161,7 @@ export interface MatchChain<TSubject, TResult = never> {
   otherwise: (handler: Handler<TResult>) => TResult
   default: (handler: Handler<TResult>) => TResult
   get: () => TResult
+  exhaustive: () => TResult
   /** @deprecated use get() */
   valueOf: () => TResult
   run: () => boolean
@@ -118,7 +170,8 @@ export interface MatchChain<TSubject, TResult = never> {
 ```
 
 Simplified for readability: the real declaration threads an extra inference type parameter through
-each method so handler return types accumulate. See
+each method so handler return types accumulate, and carries a phantom `TRemaining` parameter that
+`exhaustive()` reads to decide whether the chain is complete. See
 [Inferred vs Pinned Result Types](/guide/type-safety#inferred-vs-pinned-result-types).
 
 **Type Parameters:**
@@ -126,6 +179,11 @@ each method so handler return types accumulate. See
 - `TSubject` - The type of values being matched
 - `TResult` - The accumulated return type of handler functions. Leave it at its `never` default to
   have handler return types inferred; pass it explicitly to pin the chain.
+- `TPinned` - Internal. Whether `TResult` was pinned by the consumer rather than inferred; derived
+  from `TResult` and never passed by hand.
+- `TRemaining` - Internal. The subject values no arm has covered yet. It starts as `TSubject` and
+  shrinks as literal patterns are added; reaching `never` is what unlocks
+  [`exhaustive()`](/api/#exhaustive-tresult).
 
 **Example:**
 

--- a/docs/guide/advanced-patterns.md
+++ b/docs/guide/advanced-patterns.md
@@ -103,6 +103,88 @@ console.log(processScore(90)) // "High"
 console.log(processScore(60)) // "Medium"
 ```
 
+## Composing Guards
+
+`.on()` takes a single predicate per arm, so combining conditions otherwise means writing a wrapper
+lambda for every combination. `not`, `allOf` and `anyOf` give the three useful shapes a name:
+
+```typescript
+import { allOf, anyOf, match, not } from '@anilkumarthakur/match'
+
+interface User {
+  role: 'admin' | 'owner' | 'member'
+  suspended: boolean
+  verified: boolean
+}
+
+const isVerified = (u: User) => u.verified
+const isSuspended = (u: User) => u.suspended
+const isAdmin = (u: User) => u.role === 'admin'
+const isOwner = (u: User) => u.role === 'owner'
+
+const access = (user: User): string =>
+  match(user)
+    .on(allOf(isVerified, not(isSuspended)), () => 'full')
+    .on(anyOf(isAdmin, isOwner), () => 'privileged')
+    .otherwise(() => 'blocked')
+```
+
+Compare that with the hand-rolled equivalent, which buries the intent in punctuation:
+
+```typescript
+match(user)
+  .on(
+    (u) => u.verified && !u.suspended,
+    () => 'full'
+  )
+  .on(
+    (u) => u.role === 'admin' || u.role === 'owner',
+    () => 'privileged'
+  )
+  .otherwise(() => 'blocked')
+```
+
+Each combinator returns a plain `Predicate<T>`, so they nest freely:
+
+```typescript
+const isSmall = (n: number) => n < 10
+const isPositive = (n: number) => n > 0
+const isEven = (n: number) => n % 2 === 0
+
+const guard = allOf(isPositive, anyOf(isEven, isSmall), not(isSmall))
+
+guard(20) // true  — positive, even, not small
+guard(21) // false — odd and not small, so anyOf fails
+guard(4) // false — small, so not(isSmall) fails
+```
+
+Evaluation short-circuits left to right, exactly like `&&` and `||`, so put the cheap checks first.
+
+| Helper                 | Matches when                   | With no arguments      |
+| ---------------------- | ------------------------------ | ---------------------- |
+| `not(p)`               | `p` does not match             | n/a                    |
+| `allOf(...predicates)` | every predicate matches        | matches **everything** |
+| `anyOf(...predicates)` | at least one predicate matches | matches **nothing**    |
+
+The empty cases follow `Array.prototype.every` and `some`, which makes it safe to spread a
+possibly-empty list of conditions into either:
+
+```typescript
+const rules: Predicate<User>[] = getEnabledRules() // may be empty
+match(user)
+  .on(allOf(...rules), () => 'passes every enabled rule')
+  .otherwise(() => 'rejected')
+```
+
+::: tip
+`anyOf` composes _conditions_;
+[`onAny()`](/api/#onany-values-readonly-tsubject-handler-tresult-this) compares the subject against a
+list of _values_. Similar names, different jobs.
+:::
+
+Because a combinator is still a predicate, it does not contribute to
+[`exhaustive()`](/guide/type-safety#checked-exhaustiveness) coverage.
+
 ## Object Shape Checking
 
 Use predicates for structural validation:

--- a/docs/guide/type-safety.md
+++ b/docs/guide/type-safety.md
@@ -38,7 +38,7 @@ const result = match<number | string, boolean>(42)
 
 ## Union Types
 
-Match on union types for exhaustiveness:
+Match on union types, covering every member:
 
 ```typescript
 type Status = 'pending' | 'active' | 'inactive' | 'deleted'
@@ -49,11 +49,117 @@ const getStatusLabel = (status: Status): string => {
     .on('active', () => 'Active')
     .on('inactive', () => 'Inactive')
     .on('deleted', () => 'Deleted')
-    .otherwise(() => 'Unknown') // Never reached, but good practice
+    .otherwise(() => 'Unknown') // Never reached
 }
 
 console.log(getStatusLabel('active')) // "Active"
 ```
+
+That trailing `otherwise()` is unreachable, and it is also load-bearing in the wrong way: it is what
+lets a _new_ `Status` member slip through silently. Prefer `exhaustive()` when you want the compiler
+to notice.
+
+## Checked Exhaustiveness
+
+`exhaustive()` resolves a chain with no fallback at all, and only compiles once every member of the
+subject's union has an arm:
+
+```typescript
+type Status = 'pending' | 'active' | 'inactive' | 'deleted'
+
+const getStatusLabel = (status: Status): string =>
+  match<Status, string>(status)
+    .on('pending', () => 'Pending Review')
+    .on('active', () => 'Active')
+    .on('inactive', () => 'Inactive')
+    .on('deleted', () => 'Deleted')
+    .exhaustive()
+```
+
+Remove an arm and the call fails to compile:
+
+```typescript
+match<Status, string>(status)
+  .on('pending', () => 'Pending Review')
+  .on('active', () => 'Active')
+  .exhaustive()
+// ✗ Expected 1 arguments, but got 0.
+//   Parameter type: NonExhaustive<"inactive" | "deleted">
+```
+
+The point is not catching today's typo — it is the change six months from now. Add `'archived'` to
+`Status` and **every** `exhaustive()` chain over it stops compiling until handled. The `otherwise()`
+version above keeps compiling and silently returns `'Unknown'`.
+
+`onAny()` covers every value it lists, so it participates too:
+
+```typescript
+match<Status, string>(status)
+  .onAny(['pending', 'active'], () => 'Open')
+  .onAny(['inactive', 'deleted'], () => 'Closed')
+  .exhaustive() // ✅ all four covered
+```
+
+### What counts as coverage
+
+Only **literal** arms. A predicate's result cannot be evaluated by the type system, so a guard leaves
+the remainder untouched:
+
+```typescript
+match<Status, string>(status)
+  .on('pending', () => 'Open')
+  .on(
+    (s) => s !== 'pending',
+    () => 'Other'
+  ) // covers the rest at runtime...
+  .exhaustive() // ...but ✗ still: a guard proves nothing statically
+```
+
+This is deliberate. The alternative — trusting a guard — would be a guarantee the library cannot
+honour. Use `otherwise()` on guard-driven chains.
+
+Open-ended subject types are never exhaustible, for the same reason:
+
+```typescript
+const f = (s: string) =>
+  match<string, string>(s)
+    .on('a', () => 'A')
+    .exhaustive() // ✗ `string` has infinitely many remaining values
+```
+
+Narrow the subject to a union first.
+
+### It still throws at runtime
+
+The guarantee is only as strong as the subject's declared type. A value that dodged the type system —
+an unvalidated API payload, a cast — can reach a chain the compiler believes is total, so
+`exhaustive()` keeps `get()`'s runtime behaviour:
+
+```typescript
+const smuggled = 'archived' as Status
+
+match<Status, string>(smuggled)
+  .on('pending', () => 'Open')
+  .on('active', () => 'Active')
+  .on('inactive', () => 'Inactive')
+  .on('deleted', () => 'Deleted')
+  .exhaustive() // compiles, then throws UnhandledMatchError
+```
+
+A loud error beats a silent `undefined`. Validate at the boundary and the two agree.
+
+### A TypeScript gotcha with inferred subjects
+
+Control-flow analysis narrows an annotated `const` to the literal it was assigned, so the inferred
+subject type follows suit:
+
+```typescript
+const status: Status = 'active'
+match(status).on('pending', () => 1) // ✗ TSubject inferred as 'active', not Status
+```
+
+Pass the subject as a function parameter (as in the examples above), or pin it explicitly with
+`match<Status, string>(status)`, and the full union survives.
 
 ## Strict Type Checking
 

--- a/packages/match/README.md
+++ b/packages/match/README.md
@@ -15,6 +15,8 @@ PHP-style match expressions for JavaScript/TypeScript with 100% type safety and 
 🎯 **Readable**: Clean, expressive syntax inspired by PHP match expressions  
 🚀 **Fast**: Eager, allocation-free matching — a single `Object.is` per case, no lookup table to build  
 🛡️ **Guards**: Predicate functions, not just literals — the headline extension over PHP's `match`  
+✅ **Exhaustive**: `.exhaustive()` makes an uncovered union member a _compile_ error, not a runtime one  
+🧩 **Composable**: `not`/`allOf`/`anyOf` combine guards without hand-written wrapper lambdas  
 📦 **Lightweight**: Zero dependencies, ~1 KB gzipped (ES module)  
 🧪 **Well-Tested**: Comprehensive test suite at 100% code coverage  
 🔗 **Chainable**: Fluent API for method chaining  
@@ -176,6 +178,66 @@ const result = match('test')
   .get() // Must have matched something
 ```
 
+### `exhaustive(): TResult`
+
+The checked counterpart to [`get()`](#get-tresult). Resolves the chain, but only compiles once
+every member of the subject's union has an arm. Reach for it when forgetting a case should break
+the build rather than surface in production.
+
+**Returns:** The result from the matched handler
+
+**Throws:** `UnhandledMatchError` if no case matched at runtime
+
+**Example:**
+
+```typescript
+type Status = 'active' | 'archived' | 'draft'
+
+const label = (status: Status): string =>
+  match<Status, string>(status)
+    .on('active', () => 'Live')
+    .on('archived', () => 'Archived')
+    .on('draft', () => 'Draft')
+    .exhaustive() // ✅ compiles: nothing left over
+```
+
+Drop an arm and the call stops compiling. The diagnostic names the gap:
+
+```typescript
+const label = (status: Status): string =>
+  match<Status, string>(status)
+    .on('active', () => 'Live')
+    .on('archived', () => 'Archived')
+    .exhaustive()
+//   ~~~~~~~~~~
+// Expected 1 arguments, but got 0.
+//   The parameter is NonExhaustive<"draft">, naming the case with no arm.
+```
+
+The real payoff is later: add `'pending'` to `Status` six months from now and **every**
+`.exhaustive()` chain over it fails to compile until it is handled. A `switch` with a `default`, or
+an `.otherwise()`, would silently take the fallback branch instead.
+
+Three things worth knowing:
+
+- **Only literal arms count.** A predicate's outcome is not knowable statically, so a guard leaves
+  the remainder untouched and `.exhaustive()` stays unavailable. That is deliberate — the
+  alternative is a guarantee the library cannot honour. Use `otherwise()` on guard-driven chains.
+- **Open-ended subjects are never exhaustible.** A subject typed as all of `string` or `number` has
+  infinitely many remaining values, so no finite set of arms unlocks the call. Narrow the subject to
+  a union first.
+- **It still throws at runtime.** The guarantee is only as strong as the subject's declared type; an
+  unvalidated API payload cast to `Status` can reach a chain the compiler believes is total. Better a
+  loud `UnhandledMatchError` than a silent `undefined`.
+
+```typescript
+// `onAny` covers every value it lists, so this is exhaustive too.
+match<Status, string>(status)
+  .onAny(['active', 'draft'], () => 'Editable')
+  .on('archived', () => 'Frozen')
+  .exhaustive()
+```
+
 ### `valueOf(): TResult`
 
 Deprecated alias for [`get()`](#get-tresult). Prefer `get()`.
@@ -221,6 +283,43 @@ you can inspect a matcher and keep adding cases.
 const matcher = match('test').on('test', () => 'matched')
 console.log(matcher.isMatched) // true
 ```
+
+### Guard combinators: `not`, `allOf`, `anyOf`
+
+`.on()` takes one predicate per arm, so composing conditions otherwise means writing a wrapper
+lambda for each combination. These three give the useful shapes a name:
+
+```typescript
+import { allOf, anyOf, match, not } from '@anilkumarthakur/match'
+
+const isVerified = (u: User) => u.verified
+const isSuspended = (u: User) => u.suspended
+const isAdmin = (u: User) => u.role === 'admin'
+const isOwner = (u: User) => u.role === 'owner'
+
+match(user)
+  .on(allOf(isVerified, not(isSuspended)), () => 'ok')
+  .on(anyOf(isAdmin, isOwner), () => 'privileged')
+  .otherwise(() => 'blocked')
+```
+
+Each returns a plain `Predicate<T>`, so they nest freely and work anywhere a predicate is accepted.
+Evaluation short-circuits left to right, exactly like `&&` and `||` — put the cheap checks first.
+
+| Helper                 | Matches when                   | With no arguments      |
+| ---------------------- | ------------------------------ | ---------------------- |
+| `not(p)`               | `p` does not match             | n/a                    |
+| `allOf(...predicates)` | every predicate matches        | matches **everything** |
+| `anyOf(...predicates)` | at least one predicate matches | matches **nothing**    |
+
+The empty cases follow `Array.prototype.every`/`some`, which makes it safe to spread a
+possibly-empty list of conditions into either one.
+
+> `anyOf` composes _conditions_; [`onAny`](#onanyvalues-readonly-tsubject-handler---tresult-matcher)
+> compares the subject against a list of _values_. Different jobs, similar names.
+
+Because combinators are predicates, they do not contribute to
+[`exhaustive()`](#exhaustive-tresult) coverage.
 
 ### `UnhandledMatchError`
 
@@ -457,6 +556,11 @@ const result = match(status)
   .otherwise(() => 'Unknown')
 ```
 
+Two places this goes beyond PHP: predicate arms (PHP compares with `===` only), and
+[`exhaustive()`](#exhaustive-tresult), which turns a missing case into a compile error. PHP can only
+raise `UnhandledMatchError` at runtime — the same fallback this library keeps for values that dodge
+the type system.
+
 ## Supported Types
 
 The library supports matching on any JavaScript type. Literal comparison uses `Object.is()`, **not**
@@ -538,7 +642,27 @@ const result3 = match<Status, string>('success')
   .on('pending', () => 'In progress')
   .on('error', () => 'Failed')
   .otherwise(() => 'Unknown')
+
+// Checked exhaustiveness — no fallback, and a missing arm is a compile error
+const result4 = match<Status, string>('success')
+  .on('success', () => 'Done')
+  .on('pending', () => 'In progress')
+  .on('error', () => 'Failed')
+  .exhaustive()
 ```
+
+See [`exhaustive()`](#exhaustive-tresult) for what does and does not count towards coverage.
+
+One TypeScript behaviour to be aware of when the result type is inferred: control-flow analysis
+narrows an annotated `const` to the literal it was assigned, so the subject type follows suit.
+
+```typescript
+const status: Status = 'success'
+match(status).on('pending', () => 1) // ✗ TSubject inferred as 'success', not Status
+```
+
+Pass the subject as a function parameter, or pin it with `match<Status, string>(status)`, and the
+full union is preserved.
 
 ## Performance
 
@@ -548,6 +672,24 @@ const result3 = match<Status, string>('success')
   `match` expression realistically has, a few identity comparisons beat building a hash map.
 - 💾 Only the first matching handler executes; later `.on()` calls short-circuit to no-ops
 - 📦 Roughly 3 kB raw / 1 kB gzipped per format (ESM, CJS, IIFE)
+- 🧮 Each chain allocates one `Matcher` and one closure per arm. A `switch` compiles to a jump table
+  and will win a microbenchmark; at the volumes real dispatch code runs at, the difference is noise
+  against the readability. If a chain genuinely is hot, `switch` is the right tool.
+
+## Not in scope
+
+Deliberate omissions, so the boundaries are clear:
+
+- **Structural / deep pattern matching.** There is no matching on object _shape_ — no
+  `{ type: 'circle', radius: _ }` patterns, no destructuring, no wildcards. Patterns are compared
+  with `Object.is()`, which means objects and arrays match by reference only. This mirrors PHP's
+  `match`, which is likewise a strict-equality construct. If you need shape-based matching with
+  bindings, a dedicated library such as [ts-pattern](https://github.com/gvergnaud/ts-pattern) solves
+  a genuinely different problem — reach for a predicate here, or that there.
+- **Exhaustiveness over predicates or open-ended types.** Covered under
+  [`exhaustive()`](#exhaustive-tresult): only literal arms can be proven to cover anything.
+- **Async handlers as a special case.** Handlers may return promises like any other value, but the
+  chain does not await them; `match(...)...get()` resolves to a `Promise` you await yourself.
 
 ## Testing
 
@@ -568,8 +710,10 @@ Test categories:
 
 - Basic functionality
 - Type matching (strings, numbers, booleans, objects, arrays, etc.)
-- All API methods (`on`, `onAny`, `otherwise`, `default`, `get`/`valueOf`, `run`, `isMatched`)
-- Predicate matching and function subjects
+- All API methods (`on`, `onAny`, `otherwise`, `default`, `get`/`valueOf`, `exhaustive`, `run`,
+  `isMatched`)
+- Predicate matching, guard combinators (`not`/`allOf`/`anyOf`) and function subjects
+- Compile-time exhaustiveness, asserted with `@ts-expect-error` so a regression fails `tsc`
 - Error handling
 - Type safety
 - Real-world examples

--- a/packages/match/src/guards.ts
+++ b/packages/match/src/guards.ts
@@ -1,0 +1,95 @@
+import type { Predicate } from './types'
+
+/**
+ * Combinators for building one predicate out of several.
+ *
+ * `.on()` takes a single predicate per arm, so composing conditions otherwise
+ * means hand-writing a wrapper lambda for each combination. These give the three
+ * useful shapes a name, keeping the guard readable at the call site:
+ *
+ * ```typescript
+ * match(user)
+ *   .on(allOf(isVerified, not(isSuspended)), () => 'ok')
+ *   .otherwise(() => 'blocked')
+ * ```
+ *
+ * All three return a plain `Predicate<T>`, so they nest freely and work anywhere
+ * a predicate is accepted. Evaluation is short-circuiting and left-to-right,
+ * matching `&&`/`||`: put the cheap checks first.
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * Negate a predicate.
+ *
+ * @template T The type of the value being matched against
+ * @param predicate The predicate to invert
+ * @returns A predicate matching exactly when `predicate` does not
+ *
+ * @example
+ * ```typescript
+ * const isEmpty: Predicate<string> = (s) => s.length === 0
+ *
+ * match('hello')
+ *   .on(not(isEmpty), () => 'has content')
+ *   .otherwise(() => 'empty')
+ * // 'has content'
+ * ```
+ */
+export function not<T>(predicate: Predicate<T>): Predicate<T> {
+  return (value) => !predicate(value)
+}
+
+/**
+ * Require every predicate to hold.
+ *
+ * Short-circuits on the first failure. With no predicates it matches
+ * everything — the vacuous-truth reading, consistent with `Array.every` — which
+ * makes it safe to spread a possibly-empty list of conditions into it.
+ *
+ * @template T The type of the value being matched against
+ * @param predicates The predicates that must all hold
+ * @returns A predicate matching only when every argument matches
+ *
+ * @example
+ * ```typescript
+ * const isPositive: Predicate<number> = (n) => n > 0
+ * const isEven: Predicate<number> = (n) => n % 2 === 0
+ *
+ * match(4)
+ *   .on(allOf(isPositive, isEven), () => 'positive and even')
+ *   .otherwise(() => 'something else')
+ * // 'positive and even'
+ * ```
+ */
+export function allOf<T>(...predicates: readonly Predicate<T>[]): Predicate<T> {
+  return (value) => predicates.every((predicate) => predicate(value))
+}
+
+/**
+ * Require at least one predicate to hold.
+ *
+ * Short-circuits on the first success. With no predicates it matches nothing —
+ * consistent with `Array.some`, and the mirror of `allOf`'s empty case.
+ *
+ * Distinct from `onAny`, which compares the subject against a list of *values*;
+ * this composes a list of *conditions*.
+ *
+ * @template T The type of the value being matched against
+ * @param predicates The candidate predicates
+ * @returns A predicate matching when any argument matches
+ *
+ * @example
+ * ```typescript
+ * const isAdmin: Predicate<User> = (u) => u.role === 'admin'
+ * const isOwner: Predicate<User> = (u) => u.role === 'owner'
+ *
+ * match(user)
+ *   .on(anyOf(isAdmin, isOwner), () => 'may edit')
+ *   .otherwise(() => 'read only')
+ * ```
+ */
+export function anyOf<T>(...predicates: readonly Predicate<T>[]): Predicate<T> {
+  return (value) => predicates.some((predicate) => predicate(value))
+}

--- a/packages/match/src/index.ts
+++ b/packages/match/src/index.ts
@@ -22,10 +22,22 @@
  *   .otherwise(() => 'Unknown')
  * ```
  *
+ * @example Checked Exhaustiveness
+ * ```typescript
+ * type Status = 'active' | 'archived'
+ *
+ * // Fails to compile if a Status gains a member and this chain is not updated.
+ * const label = match<Status, string>(status)
+ *   .on('active', () => 'Live')
+ *   .on('archived', () => 'Archived')
+ *   .exhaustive()
+ * ```
+ *
  * @packageDocumentation
  */
 
 export { match, Matcher } from './matcher'
+export { allOf, anyOf, not } from './guards'
 export { UnhandledMatchError } from './errors'
 // `MatcherHandler` is deprecated in favour of `Handler`, but it stays exported
 // so existing consumers keep compiling — removing it would be a breaking
@@ -36,7 +48,9 @@ export type {
   MatchChain,
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   MatcherHandler,
+  NonExhaustive,
   Pattern,
   Predicate,
-  ResultHandler
+  ResultHandler,
+  Unmatched
 } from './types'

--- a/packages/match/src/matcher.ts
+++ b/packages/match/src/matcher.ts
@@ -1,4 +1,12 @@
-import type { IsPinned, MatchChain, Pattern, Predicate, ResultHandler } from './types'
+import type {
+  IsPinned,
+  MatchChain,
+  NonExhaustive,
+  Pattern,
+  Predicate,
+  ResultHandler,
+  Unmatched
+} from './types'
 import { UnhandledMatchError } from './errors'
 
 /**
@@ -17,8 +25,12 @@ export class Matcher<
   // Derived, never passed explicitly: it remembers whether the chain started
   // pinned (`match<S, R>(x)`) or inferring (`match(x)`), which TResult alone can
   // no longer tell you once a handler has contributed a type to it.
-  TPinned extends boolean = IsPinned<TResult>
-> implements MatchChain<TSubject, TResult, TPinned> {
+  TPinned extends boolean = IsPinned<TResult>,
+  // Phantom, never passed explicitly: the subject values no arm has covered
+  // yet. It exists purely so `exhaustive()` can refuse to compile while cases
+  // are outstanding; nothing at runtime reads it.
+  TRemaining = TSubject
+> implements MatchChain<TSubject, TResult, TPinned, TRemaining> {
   private readonly subject: TSubject
   private matched = false
   // Stored as `unknown` because each handler contributes its own return type to
@@ -47,13 +59,15 @@ export class Matcher<
    * ```
    */
   // Deliberately not `this`: the return type folds this handler's R into
-  // TResult so the chain accumulates its handlers' return types. It is still the
-  // same instance, which is why prefer-return-this-type is suppressed here.
-  on<R = never>(
-    pattern: Pattern<TSubject>,
+  // TResult so the chain accumulates its handlers' return types, and drops this
+  // pattern from TRemaining so `exhaustive()` can tell when the arms are
+  // complete. Both are phantom — the object returned is this very instance,
+  // which is why prefer-return-this-type is suppressed here.
+  on<const TPattern extends Pattern<TSubject>, R = never>(
+    pattern: TPattern,
     handler: ResultHandler<TResult, R, TPinned>
     // eslint-disable-next-line @typescript-eslint/prefer-return-this-type
-  ): Matcher<TSubject, TResult | R, TPinned> {
+  ): Matcher<TSubject, TResult | R, TPinned, Unmatched<TSubject, TRemaining, TPattern>> {
     if (this.matched) return this
 
     // Treat pattern as predicate only if:
@@ -78,12 +92,13 @@ export class Matcher<
    * @param values - Array of literal values to match against
    * @param handler - Function to execute if any value matches
    */
-  // See `on`: the widened return type is what accumulates the result union.
-  onAny<R = never>(
-    values: readonly TSubject[],
+  // See `on`: the widened return type is what accumulates the result union, and
+  // every listed value is a literal, so all of them leave TRemaining.
+  onAny<const TValues extends readonly TSubject[], R = never>(
+    values: TValues,
     handler: ResultHandler<TResult, R, TPinned>
     // eslint-disable-next-line @typescript-eslint/prefer-return-this-type
-  ): Matcher<TSubject, TResult | R, TPinned> {
+  ): Matcher<TSubject, TResult | R, TPinned, Exclude<TRemaining, TValues[number]>> {
     if (this.matched) return this
 
     if (values.some((v) => Object.is(this.subject, v))) {
@@ -111,6 +126,49 @@ export class Matcher<
    */
   default<R = never>(handler: ResultHandler<TResult, R, TPinned>): TResult | R {
     return this.otherwise<R>(handler)
+  }
+
+  /**
+   * Resolve the chain, requiring at compile time that every case is covered.
+   *
+   * This is the checked counterpart to `get()`. Both throw on an unmatched
+   * subject at runtime; the difference is that reaching `exhaustive()` at all
+   * means the compiler has already confirmed no declared subject value is left
+   * without an arm. Add a case to the union later and every `exhaustive()` chain
+   * over it stops compiling — the failure moves from production to the build.
+   *
+   * The guarantee is only as good as the subject's declared type, which is why
+   * it still throws: a value smuggled past the type system (an unvalidated API
+   * payload, a cast) can reach a chain the compiler believes is total.
+   *
+   * Only literal arms count towards coverage. A chain that discriminates with
+   * predicates keeps its full remainder and cannot call this — use
+   * `otherwise()` there, since a guard's outcome is not knowable statically.
+   *
+   * @param _args Nothing, once no cases remain. While cases are still missing the
+   *   signature demands one argument of an unconstructable type, so the call
+   *   fails to compile; hover it to see which values are unhandled.
+   * @throws {UnhandledMatchError} If no arm matched at runtime
+   * @returns The result from the matched handler
+   *
+   * @example
+   * ```typescript
+   * type Status = 'active' | 'archived'
+   *
+   * const label = (status: Status): string =>
+   *   match<Status, string>(status)
+   *     .on('active', () => 'Live')
+   *     .on('archived', () => 'Archived')
+   *     .exhaustive()
+   * ```
+   */
+  exhaustive(
+    // Unused at runtime: the parameter exists only to make the call fail to
+    // typecheck while TRemaining is inhabited. Prefixed so `noUnusedParameters`
+    // and the lint rule both accept it.
+    ..._args: [TRemaining] extends [never] ? [] : [error: NonExhaustive<TRemaining>]
+  ): TResult {
+    return this.get()
   }
 
   /**

--- a/packages/match/src/types.ts
+++ b/packages/match/src/types.ts
@@ -39,6 +39,19 @@ export type Predicate<T> = (value: T) => boolean
 export type MatcherHandler<T> = Handler<T>
 
 /**
+ * The shape every function value is assignable to.
+ *
+ * Used to ask "is this type a function?" without naming a signature. The
+ * `never[]` parameter list keeps it maximally permissive: parameters are
+ * checked contravariantly, so a function type satisfies this regardless of what
+ * it actually accepts.
+ *
+ * Deliberately not exported — it is an implementation detail of `Pattern` and
+ * `Unmatched`, not part of the API consumers write against.
+ */
+type AnyFunction = (...args: never[]) => unknown
+
+/**
  * The set of patterns `.on()` accepts for a given subject type.
  *
  * This mirrors the runtime rule in `Matcher#on`: a function pattern is only
@@ -60,7 +73,7 @@ export type MatcherHandler<T> = Handler<T>
  * type P2 = Pattern<() => string> // () => string  (no predicate arm)
  * ```
  */
-export type Pattern<TSubject> = [TSubject] extends [(...args: never[]) => unknown]
+export type Pattern<TSubject> = [TSubject] extends [AnyFunction]
   ? TSubject
   : TSubject | Predicate<TSubject>
 
@@ -100,6 +113,68 @@ export type ResultHandler<
 > = TPinned extends true ? Handler<TResult> : Handler<R>
 
 /**
+ * The subject values still unaccounted for after one `.on(pattern)` arm.
+ *
+ * Only a *literal* pattern proves anything about coverage: an arm matching
+ * `'a'` removes `'a'` from what remains. A predicate cannot be evaluated by the
+ * type system, so a predicate arm leaves the remainder untouched — which is why
+ * `.exhaustive()` never accepts a chain that leans on guards. Reporting "still
+ * incomplete" there is the honest answer, not a limitation to work around.
+ *
+ * The function-subject case is tested first to mirror `Pattern`: when the
+ * subject is itself a function the pattern is an identity comparison rather
+ * than a predicate, so it does narrow.
+ *
+ * Note that `Exclude` only removes members of a union. A subject typed as the
+ * whole of `string` therefore never narrows to `never`, so `.exhaustive()`
+ * stays unavailable for it — correctly, since no finite set of arms can cover
+ * every string.
+ *
+ * @template TSubject The type of the value being matched against
+ * @template TRemaining The values not yet covered by earlier arms
+ * @template TPattern The pattern this arm was given
+ *
+ * @example
+ * ```typescript
+ * type A = Unmatched<'a' | 'b', 'a' | 'b', 'a'>              // 'b'
+ * type B = Unmatched<'a' | 'b', 'a' | 'b', Predicate<'a'>>   // 'a' | 'b'
+ * ```
+ */
+export type Unmatched<TSubject, TRemaining, TPattern> = [TSubject] extends [AnyFunction]
+  ? Exclude<TRemaining, TPattern>
+  : [TPattern] extends [AnyFunction]
+    ? TRemaining
+    : Exclude<TRemaining, TPattern>
+
+/**
+ * The argument `.exhaustive()` demands when cases are still missing.
+ *
+ * No value of this type can be produced — `nonExhaustive` is typed `never` — so
+ * the call cannot be satisfied. That is the entire point: the diagnostic is the
+ * feature, not the value. TypeScript reports the missing argument and names
+ * this type, whose `missingCases` parameter spells out on hover exactly which
+ * subject values are still unhandled.
+ *
+ * @template TRemaining The subject values still lacking an arm
+ *
+ * @example
+ * ```typescript
+ * declare const status: 'active' | 'archived'
+ * match<'active' | 'archived', string>(status)
+ *   .on('active', () => 'live')
+ *   // Error: expected 1 argument. The parameter is
+ *   // NonExhaustive<'archived'>, naming the case that is missing.
+ *   .exhaustive()
+ * ```
+ */
+export interface NonExhaustive<TRemaining> {
+  /** Documentation-only: hovering the type reports the uncovered cases. */
+  readonly missingCases: TRemaining
+  /** `never` is what makes the whole object impossible to construct. */
+  readonly nonExhaustive: never
+}
+
+/**
  * Interface representing a chainable match expression
  *
  * Provides the API contract for method chaining in match expressions. It
@@ -112,6 +187,9 @@ export type ResultHandler<
  *   at its `never` default to have handler return types inferred.
  * @template TPinned Internal: whether TResult was pinned by the consumer rather
  *   than inferred. It is derived from TResult and should not be passed by hand.
+ * @template TRemaining Internal: the subject values no arm has covered yet. It
+ *   starts as TSubject and shrinks as literal patterns are added; reaching
+ *   `never` is what unlocks `.exhaustive()`.
  *
  * @example
  * ```typescript
@@ -125,7 +203,8 @@ export type ResultHandler<
 export interface MatchChain<
   TSubject,
   TResult = never,
-  TPinned extends boolean = IsPinned<TResult>
+  TPinned extends boolean = IsPinned<TResult>,
+  TRemaining = TSubject
 > {
   /**
    * Alias for otherwise() - PHP compatibility
@@ -134,6 +213,18 @@ export interface MatchChain<
    * @returns The result from matched handler or default
    */
   default: <R = never>(handler: ResultHandler<TResult, R, TPinned>) => TResult | R
+
+  /**
+   * Resolve the chain, requiring at compile time that every case is covered
+   *
+   * @param args Nothing, once no cases remain. While cases are still missing the
+   *   signature demands one unconstructable argument, so the call fails to
+   *   compile and names them.
+   * @returns The result from the matched handler
+   */
+  exhaustive: (
+    ...args: [TRemaining] extends [never] ? [] : [error: NonExhaustive<TRemaining>]
+  ) => TResult
 
   /**
    * Get the matched result without a fallback
@@ -153,11 +244,12 @@ export interface MatchChain<
    * @param pattern A literal value to match with Object.is, or a predicate
    * @param handler Function to execute if matched
    * @returns The matcher for chaining, with this handler's return type folded in
+   *   and this pattern removed from what `.exhaustive()` still requires
    */
-  on: <R = never>(
-    pattern: Pattern<TSubject>,
+  on: <const TPattern extends Pattern<TSubject>, R = never>(
+    pattern: TPattern,
     handler: ResultHandler<TResult, R, TPinned>
-  ) => MatchChain<TSubject, TResult | R, TPinned>
+  ) => MatchChain<TSubject, TResult | R, TPinned, Unmatched<TSubject, TRemaining, TPattern>>
 
   /**
    * Match against any of the provided literal values
@@ -165,11 +257,12 @@ export interface MatchChain<
    * @param values Array of literal values to match against
    * @param handler Function to execute if any value matches
    * @returns The matcher for chaining, with this handler's return type folded in
+   *   and every listed value removed from what `.exhaustive()` still requires
    */
-  onAny: <R = never>(
-    values: readonly TSubject[],
+  onAny: <const TValues extends readonly TSubject[], R = never>(
+    values: TValues,
     handler: ResultHandler<TResult, R, TPinned>
-  ) => MatchChain<TSubject, TResult | R, TPinned>
+  ) => MatchChain<TSubject, TResult | R, TPinned, Exclude<TRemaining, TValues[number]>>
 
   /**
    * Set default handler and execute the match

--- a/packages/match/test/exhaustive-and-guards.test.ts
+++ b/packages/match/test/exhaustive-and-guards.test.ts
@@ -1,0 +1,297 @@
+import { allOf, anyOf, match, not, UnhandledMatchError } from '@'
+import type { NonExhaustive, Predicate, Unmatched } from '@'
+
+/**
+ * Suite for `.exhaustive()` and the guard combinators.
+ *
+ * As with `typing-and-terminal.test.ts`, much of the value is in the compile
+ * step: this file is inside tsconfig's `include`, so the `@ts-expect-error`
+ * directives below fail `tsc --noEmit` if the exhaustiveness check ever stops
+ * rejecting an incomplete chain — a silent regression that no runtime assertion
+ * could catch, since an incomplete chain still *runs* perfectly well.
+ */
+
+type Status = 'active' | 'archived' | 'draft'
+
+describe('exhaustive() - compile-time coverage', () => {
+  test('accepts a chain that covers every union member', () => {
+    const label = (status: Status): string =>
+      match<Status, string>(status)
+        .on('active', () => 'Live')
+        .on('archived', () => 'Archived')
+        .on('draft', () => 'Draft')
+        .exhaustive()
+
+    expect(label('active')).toBe('Live')
+    expect(label('archived')).toBe('Archived')
+    expect(label('draft')).toBe('Draft')
+  })
+
+  test('rejects a chain with a member still uncovered', () => {
+    const label = (status: Status): string =>
+      match<Status, string>(status)
+        .on('active', () => 'Live')
+        .on('archived', () => 'Archived')
+        // @ts-expect-error 'draft' has no arm, so exhaustive() demands an argument
+        .exhaustive()
+
+    // The call still works at runtime for the covered members — the missing arm
+    // is a type error, not a behaviour change.
+    expect(label('active')).toBe('Live')
+  })
+
+  test('rejects a chain with no arms at all', () => {
+    expect(() =>
+      match<Status, string>('active')
+        // @ts-expect-error nothing is covered
+        .exhaustive()
+    ).toThrow(UnhandledMatchError)
+  })
+
+  test('onAny covers every value it lists', () => {
+    const kind = (status: Status): string =>
+      match<Status, string>(status)
+        .onAny(['active', 'draft'], () => 'editable')
+        .on('archived', () => 'frozen')
+        .exhaustive()
+
+    expect(kind('active')).toBe('editable')
+    expect(kind('draft')).toBe('editable')
+    expect(kind('archived')).toBe('frozen')
+  })
+
+  test('onAny leaves anything it does not list', () => {
+    const kind = (status: Status): string =>
+      match<Status, string>(status)
+        .onAny(['active', 'draft'], () => 'editable')
+        // @ts-expect-error 'archived' is still uncovered
+        .exhaustive()
+
+    expect(kind('active')).toBe('editable')
+  })
+
+  test('numeric and boolean unions narrow the same way', () => {
+    const parity = (n: 1 | 2): string =>
+      match<1 | 2, string>(n)
+        .on(1, () => 'one')
+        .on(2, () => 'two')
+        .exhaustive()
+    expect(parity(2)).toBe('two')
+
+    const flag = (b: boolean): string =>
+      match<boolean, string>(b)
+        .on(true, () => 'yes')
+        .on(false, () => 'no')
+        .exhaustive()
+    expect(flag(true)).toBe('yes')
+  })
+
+  test('a predicate arm proves nothing, so the remainder survives', () => {
+    // Deliberate: a guard's outcome is not statically knowable, so covering
+    // 'archived' | 'draft' by predicate must NOT unlock exhaustive().
+    const isNotActive: Predicate<Status> = (s) => s !== 'active'
+
+    const label = (status: Status): string =>
+      match<Status, string>(status)
+        .on('active', () => 'Live')
+        .on(isNotActive, () => 'Other')
+        // @ts-expect-error a predicate leaves 'archived' | 'draft' outstanding
+        .exhaustive()
+
+    expect(label('draft')).toBe('Other')
+  })
+
+  test('an open-ended subject type is never exhaustible', () => {
+    // Exclude cannot empty `string`, and no finite set of arms covers it, so the
+    // chain correctly stays unresolvable by exhaustive().
+    const label = (value: string): string =>
+      match<string, string>(value)
+        .on('a', () => 'A')
+        // @ts-expect-error `string` has infinitely many remaining values
+        .exhaustive()
+
+    expect(label('a')).toBe('A')
+  })
+
+  test('throws when the declared type was lied to at runtime', () => {
+    // The compiler believes this chain is total; the value is not really a
+    // Status. exhaustive() still throws rather than returning undefined.
+    const smuggled = 'deleted' as Status
+
+    expect(() =>
+      match<Status, string>(smuggled)
+        .on('active', () => 'Live')
+        .on('archived', () => 'Archived')
+        .on('draft', () => 'Draft')
+        .exhaustive()
+    ).toThrow(UnhandledMatchError)
+  })
+
+  test('exhaustive() is idempotent, like get()', () => {
+    const matcher = match<'a', string>('a').on('a', () => 'hit')
+    expect(matcher.exhaustive()).toBe('hit')
+    expect(matcher.exhaustive()).toBe('hit')
+  })
+
+  test('an inferring chain carries its result type through exhaustive()', () => {
+    // No pinned TResult here: the `number` annotation is what fails to compile
+    // if exhaustive() ever stops propagating the inferred union.
+    //
+    // The subject is a function parameter on purpose. An annotated `const` would
+    // be narrowed to its assigned literal by control-flow analysis, so TSubject
+    // would infer as 'active' rather than Status and the other two arms would be
+    // rejected outright — a TypeScript-wide behaviour, not a matcher one.
+    const rank = (status: Status): number =>
+      match(status)
+        .on('active', () => 1)
+        .on('archived', () => 2)
+        .on('draft', () => 3)
+        .exhaustive()
+
+    expect(rank('active')).toBe(1)
+    expect(rank('draft')).toBe(3)
+  })
+
+  test('duplicate arms are allowed and do not un-narrow', () => {
+    // The first matching arm wins at runtime; a repeat arm is redundant rather
+    // than an error, and must not resurrect the case in TRemaining.
+    const label = match<'a' | 'b', string>('a')
+      .on('a', () => 'first')
+      .on('a', () => 'second')
+      .on('b', () => 'b')
+      .exhaustive()
+    expect(label).toBe('first')
+  })
+})
+
+describe('exhaustive() - type helpers', () => {
+  test('Unmatched removes literal patterns and keeps predicate ones', () => {
+    // Assignability in both directions pins these to exactly the stated type.
+    const afterLiteral: Unmatched<'a' | 'b', 'a' | 'b', 'a'> = 'b'
+    expect(afterLiteral).toBe('b')
+
+    const afterPredicate: Unmatched<'a' | 'b', 'a' | 'b', Predicate<'a' | 'b'>> = 'a'
+    expect(afterPredicate).toBe('a')
+
+    // @ts-expect-error 'a' was removed by the literal arm
+    const removed: Unmatched<'a' | 'b', 'a' | 'b', 'a'> = 'a'
+    expect(removed).toBe('a')
+  })
+
+  test('a function subject narrows by identity rather than being read as a guard', () => {
+    const fn = (): string => 'hello'
+    type Fn = typeof fn
+
+    // Pattern<Fn> withdraws the predicate arm, so the pattern is an identity
+    // comparison and therefore does narrow.
+    const exhausted: Unmatched<Fn, Fn, Fn> = undefined as never
+    expect(exhausted).toBeUndefined()
+
+    const result = match<Fn, string>(fn)
+      .on(fn, () => 'identity')
+      .exhaustive()
+    expect(result).toBe('identity')
+  })
+
+  test('NonExhaustive cannot be satisfied', () => {
+    // The escape hatch costs an explicit `as never`, which is the point: it is
+    // visible in review rather than silently accepted.
+    const forced = match<Status, string>('active')
+      .on('active', () => 'Live')
+      .exhaustive(undefined as never)
+    expect(forced).toBe('Live')
+
+    // @ts-expect-error `nonExhaustive: never` makes the object impossible
+    const impossible: NonExhaustive<'draft'> = { missingCases: 'draft', nonExhaustive: undefined }
+    expect(impossible.missingCases).toBe('draft')
+  })
+})
+
+describe('guard combinators', () => {
+  const isPositive: Predicate<number> = (n) => n > 0
+  const isEven: Predicate<number> = (n) => n % 2 === 0
+
+  test('not - inverts a predicate', () => {
+    expect(not(isEven)(3)).toBe(true)
+    expect(not(isEven)(4)).toBe(false)
+  })
+
+  test('not - composes inside a match chain', () => {
+    const result = match(3)
+      .on(not(isEven), () => 'odd')
+      .otherwise(() => 'even')
+    expect(result).toBe('odd')
+  })
+
+  test('not - double negation returns to the original', () => {
+    expect(not(not(isEven))(4)).toBe(true)
+  })
+
+  test('allOf - requires every predicate', () => {
+    expect(allOf(isPositive, isEven)(4)).toBe(true)
+    expect(allOf(isPositive, isEven)(3)).toBe(false)
+    expect(allOf(isPositive, isEven)(-4)).toBe(false)
+  })
+
+  test('allOf - matches everything when given nothing', () => {
+    expect(allOf<number>()(0)).toBe(true)
+  })
+
+  test('allOf - short-circuits on the first failure', () => {
+    const calls: string[] = []
+    const fails: Predicate<number> = () => {
+      calls.push('first')
+      return false
+    }
+    const never: Predicate<number> = () => {
+      calls.push('second')
+      return true
+    }
+    expect(allOf(fails, never)(1)).toBe(false)
+    expect(calls).toEqual(['first'])
+  })
+
+  test('anyOf - requires at least one predicate', () => {
+    expect(anyOf(isPositive, isEven)(-4)).toBe(true)
+    expect(anyOf(isPositive, isEven)(3)).toBe(true)
+    expect(anyOf(isPositive, isEven)(-3)).toBe(false)
+  })
+
+  test('anyOf - matches nothing when given nothing', () => {
+    expect(anyOf<number>()(0)).toBe(false)
+  })
+
+  test('anyOf - short-circuits on the first success', () => {
+    const calls: string[] = []
+    const hits: Predicate<number> = () => {
+      calls.push('first')
+      return true
+    }
+    const never: Predicate<number> = () => {
+      calls.push('second')
+      return false
+    }
+    expect(anyOf(hits, never)(1)).toBe(true)
+    expect(calls).toEqual(['first'])
+  })
+
+  test('combinators nest', () => {
+    const isSmall: Predicate<number> = (n) => n < 10
+    const guard = allOf(isPositive, anyOf(isEven, isSmall), not(isSmall))
+
+    expect(guard(20)).toBe(true) // positive, even, not small
+    expect(guard(21)).toBe(false) // odd and not small -> anyOf fails
+    expect(guard(4)).toBe(false) // small -> not(isSmall) fails
+  })
+
+  test('a combinator still counts as a predicate for exhaustiveness', () => {
+    const result = match<Status, string>('draft')
+      .on(
+        anyOf<Status>((s) => s === 'draft'),
+        () => 'editable'
+      )
+      // @ts-expect-error a composed guard is still a guard: nothing is proven
+      .exhaustive()
+    expect(result).toBe('editable')
+  })
+})


### PR DESCRIPTION
Closes the two gaps that separated this library from PHP's `match` plus a modern TS matcher: an unhandled case could only ever fail at **runtime**, and composing guards meant hand-writing a wrapper lambda per combination.

## `.exhaustive()`

The checked counterpart to `get()`. Resolves a chain with no fallback, and only compiles once every member of the subject's union has an arm.

```ts
type Status = 'active' | 'archived' | 'draft'

match<Status, string>(status)
  .on('active', () => 'Live')
  .on('archived', () => 'Archived')
  .exhaustive()
//   ~~~~~~~~~~ Expected 1 arguments, but got 0.
//              Parameter type: NonExhaustive<"draft">
```

The payoff is on the *next* change rather than this one: add a member to `Status` and every `.exhaustive()` chain over it stops compiling until handled — where a `switch` default or an `.otherwise()` keeps compiling and silently takes the fallback. `onAny()` participates too, covering every value it lists.

**How it works.** A phantom `TRemaining` type parameter on `Matcher`/`MatchChain`, narrowed by each literal arm via a new `Unmatched<>` helper. While it is inhabited, `exhaustive()` demands an unconstructable `NonExhaustive<TRemaining>` argument, so the call fails to typecheck and the diagnostic names the gap.

### Deliberate limits (documented, not worked around)

- **Predicates prove nothing.** A guard's outcome isn't statically knowable, so a predicate arm leaves the remainder intact and guard-driven chains can't call `.exhaustive()`. Trusting a guard would be a guarantee the library cannot honour — use `otherwise()` there.
- **Open-ended subjects are never exhaustible.** `string`/`number` have infinitely many remaining values; `Exclude` can't empty them. Narrow to a union first.
- **It still throws at runtime.** The guarantee is only as strong as the subject's declared type, so a value cast past the type system can reach a chain the compiler believes is total. A loud `UnhandledMatchError` beats a silent `undefined`.

## `not` / `allOf` / `anyOf`

Build one `Predicate<T>` from several, so a composed guard stays readable at the call site.

```ts
match(user)
  .on(allOf(isVerified, not(isSuspended)), () => 'ok')
  .on(anyOf(isAdmin, isOwner), () => 'privileged')
  .otherwise(() => 'blocked')
```

Short-circuit left to right like `&&`/`||`. Empty cases follow `Array.prototype.every`/`some` — `allOf()` matches everything, `anyOf()` matches nothing — so a possibly-empty condition list can be spread into either.

## Explicit non-goal

Added a **"Not in scope"** section to the README recording structural/deep pattern matching as a deliberate omission. Patterns compare with `Object.is()`, mirroring PHP's own strict-equality `match`; shape matching with bindings is a genuinely different problem, and the README now points at `ts-pattern` for it. Also documents the per-chain allocation cost honestly — a `switch` compiles to a jump table and will win a microbenchmark.

## Compatibility

**No breaking changes.** `on()` and `onAny()` gained inferred `const` type parameters so the pattern's literal type is captured, but their call signatures, runtime behaviour and result inference are unchanged. All 176 pre-existing tests pass untouched — including the predicate contextual-typing and function-subject cases, which were the main risk of adding `const`.

Ships as a `minor` (changeset included): new exports `not`/`allOf`/`anyOf` and types `Unmatched`/`NonExhaustive`.

## Verification

- `pnpm verify` (typecheck + lint + format + test) passes.
- **202 tests, 100% coverage** held on all four thresholds (lines/statements/functions/branches).
- Exhaustiveness rules are asserted with `@ts-expect-error` **inside the typechecked test file**, so a regression that stops rejecting an incomplete chain fails `tsc --noEmit` rather than passing silently — no runtime assertion could catch that, since an incomplete chain still runs fine.
- A **real consumer** compiling against the built `.d.ts` gets the error; the complete chain compiles. Verified the emitted declarations carry the new API and that the private `AnyFunction` helper survives the dts rollup.
- ESM, CJS and IIFE builds smoke-tested; `check-dist` size budget ok (7.2–7.8 KB vs 12 KB); examples workspace typechecks and runs.
- **Every new documentation example** was typechecked and its claimed runtime values verified.
- Docs site builds. Fixed one bad anchor in the process — VitePress collapses consecutive hyphens in heading ids, and its dead-link check validates paths but not fragments.

## Note

The old "Union Types" doc example ended with `.otherwise(() => 'Unknown') // Never reached, but good practice`. Reframed: that arm is exactly what lets a new union member slip through silently, so it now points at `exhaustive()`.

The uncommitted root `package.json` `packageManager` bump (11.15.0 → 11.15.1) predates this work and is intentionally **not** included here.